### PR TITLE
Extend the cooldown

### DIFF
--- a/advgoogle/advgoogle.py
+++ b/advgoogle/advgoogle.py
@@ -11,7 +11,7 @@ class AdvancedGoogle:
         self.bot = bot
 
     @commands.command(pass_context=True)
-    @commands.cooldown(5, 60, commands.BucketType.user)
+    @commands.cooldown(5, 60, commands.BucketType.channel)
     async def google(self, ctx, text):
         """Its google, you search with it.
         Example: google A magical pug


### PR DESCRIPTION
The reason of this change is, if you search too fast and many users does it, Google will detect your traffic as malicious and present a captcha page which trigger an error for the command. Hopefully with this change, the Google captcha is less triggered.