### PR TITLE
Even more longer cooldown

### DIFF
--- a/advgoogle/advgoogle.py
+++ b/advgoogle/advgoogle.py
@@ -15,7 +15,7 @@ class AdvancedGoogle:
         self.session.close()
 
     @commands.command(pass_context=True)
-    @commands.cooldown(5, 60, commands.BucketType.channel)
+    @commands.cooldown(5, 60, commands.BucketType.server)
     async def google(self, ctx, text):
         """Its google, you search with it.
         Example: google A magical pug


### PR DESCRIPTION
Even after changing the cooldown based on channel cooldown, my bot that is **only** on 3 (three) server manage to trigger unusual traffic warning (pic below). With this change, hopefully, no more temporary block

![image](https://user-images.githubusercontent.com/340284/32829926-86eb2cb6-ca2e-11e7-8f21-3f42609913e1.png)
