### PR TITLE
[Welcome] Add leave messages, fixes

### DIFF
--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -31,7 +31,8 @@ class Welcome:
 
         self._welcome.register_guild(**self.default_guild_settings)
 
-    @commands.group(no_pm=True)
+    @commands.group()
+    @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
     async def welcomeset(self, ctx):
         """Sets welcome module settings"""
@@ -60,7 +61,7 @@ class Welcome:
             await ctx.send_help()
             return
 
-    @welcomeset_msg.command(name="add", no_pm=True)
+    @welcomeset_msg.command(name="add")
     async def welcomeset_msg_add(self, ctx, *, format_msg):
         """Adds a welcome message format for the guild to be chosen at random
 
@@ -80,7 +81,7 @@ class Welcome:
         await ctx.send("Welcome message added for the guild.")
         await self.send_testing_msg(ctx, msg=format_msg)
 
-    @welcomeset_msg.command(name="addleave", no_pm=True)
+    @welcomeset_msg.command(name="addleave")
     async def welcomeset_leavemsg_add(self, ctx, *, format_msg):
         """Adds a leave message format for the guild to be chosen at random
 
@@ -95,7 +96,7 @@ class Welcome:
         await ctx.send("Leave message added for the guild.")
         await self.send_testing_msg(ctx, leave=True, msg=format_msg)
 
-    @welcomeset_msg.command(name="del", no_pm=True)
+    @welcomeset_msg.command(name="del")
     async def welcomeset_msg_del(self, ctx):
         """Removes a welcome message from the random message list
         """
@@ -122,7 +123,7 @@ class Welcome:
         await ctx.send("**This message was deleted:**\n{}".format(choice))
         await self._welcome.guild(guild).GREETING.set(settings)
 
-    @welcomeset_msg.command(name="delleave", no_pm=True)
+    @welcomeset_msg.command(name="delleave")
     async def welcomeset_leavemsg_del(self, ctx):
         """Removes a leave message from the random message list
         """
@@ -149,7 +150,7 @@ class Welcome:
         await ctx.send("**This message was deleted:**\n{}".format(choice))
         await self._welcome.guild(guild).LEAVE_MSG.set(settings)
 
-    @welcomeset_msg.command(name="list", no_pm=True)
+    @welcomeset_msg.command(name="list")
     async def welcomeset_msg_list(self, ctx):
         """Lists the welcome messages of this guild
         """
@@ -161,7 +162,7 @@ class Welcome:
         for page in pagify(msg, ["\n", " "], shorten_by=20):
             await ctx.send("```\n{}\n```".format(page))
 
-    @welcomeset_msg.command(name="listleave", no_pm=True)
+    @welcomeset_msg.command(name="listleave")
     async def welcomeset_leavemsg_list(self, ctx):
         """Lists the leave messages of this guild
         """
@@ -238,13 +239,13 @@ class Welcome:
         await self._welcome.guild(guild).LEAVE_CHANNEL.set(settings)
         await self.send_testing_msg(ctx, leave=True)
 
-    @welcomeset.group(name="bot", no_pm=True)
+    @welcomeset.group(name="bot")
     async def welcomeset_bot(self, ctx):
         """Bot settings for message and role given."""
         if ctx.invoked_subcommand is None or isinstance(ctx.invoked_subcommand, commands.Group):
             return await ctx.send_help()
 
-    @welcomeset_bot.command(name="msg", no_pm=True)
+    @welcomeset_bot.command(name="msg")
     async def welcomeset_bot_msg(self, ctx, *, format_msg=None):
         """Set the welcome message for bots.
 
@@ -262,7 +263,7 @@ class Welcome:
             await self.send_testing_msg(ctx, bot=True)
 
     # TODO: Check if have permissions
-    @welcomeset_bot.command(name="role", no_pm=True)
+    @welcomeset_bot.command(name="role")
     async def welcomeset_bot_role(self, ctx, role: discord.Role = None):
         """Set the role to put bots in when they join.
         Leave blank to not give them a role."""

--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -215,9 +215,9 @@ class Welcome:
         settings = channel.id
         if not guild.get_member(self.bot.user.id).permissions_in(channel).send_messages:
             return await ctx.send(
-                "I do not have permissions to send " "messages to {0.mention}".format(channel)
+                "I do not have permissions to send messages to {0.mention}".format(channel)
             )
-        await channel.send("I will now send welcome " "messages to {0.mention}".format(channel))
+        await channel.send("I will now send welcome messages to {0.mention}".format(channel))
         await self._welcome.guild(guild).CHANNEL.set(settings)
         await self.send_testing_msg(ctx)
 
@@ -231,10 +231,10 @@ class Welcome:
         settings = channel.id
         if not guild.get_member(self.bot.user.id).permissions_in(channel).send_messages:
             return await ctx.send(
-                "I do not have permissions to send " "messages to {0.mention}".format(channel)
+                "I do not have permissions to send messages to {0.mention}".format(channel)
             )
 
-        await channel.send("I will now send leaving " "messages to {0.mention}".format(channel))
+        await channel.send("I will now send leaving messages to {0.mention}".format(channel))
         await self._welcome.guild(guild).LEAVE_CHANNEL.set(settings)
         await self.send_testing_msg(ctx, leave=True)
 
@@ -274,7 +274,7 @@ class Welcome:
             await ctx.send("Bots that join this guild will not have a role applied.")
         else:
             await ctx.send(
-                "Bots that join this guild will " "now be put into the {} role.".format(role.name)
+                "Bots that join this guild will now be put into the {} role.".format(role.name)
             )
 
     @welcomeset.command()
@@ -445,7 +445,7 @@ class Welcome:
         rand_msg = msg or rand_choice(settings["GREETING"])
         if channel is None:
             await ctx.channel.send(
-                "I can't find the specified channel. " "It might have been deleted."
+                "I can't find the specified channel. It might have been deleted."
             )
             return
 
@@ -464,5 +464,5 @@ class Welcome:
             return await lchannel.send(msg.format(ctx.message.author, guild))
         else:
             await ctx.channel.send(
-                "I do not have permissions to send messages to " "{0.mention}".format(channel)
+                "I do not have permissions to send messages to {0.mention}".format(channel)
             )

--- a/welcome/welcome.py
+++ b/welcome/welcome.py
@@ -8,14 +8,21 @@ from redbot.core.utils.chat_formatting import pagify
 
 
 class Welcome:
-    """Welcomes new members to the guild in the default channel"""
+    """Welcomes new members to the guild"""
 
     default_greeting = "Welcome {0.name} to {1.name}!"
+    default_leave = "{0.name} ({0.id}) has left the server."
 
     default_guild_settings = {
-        "GREETING": [default_greeting], "ON": False,
-        "CHANNEL": None, "WHISPER": False,
-        "BOTS_MSG": None, "BOTS_ROLE": None
+        "GREETING": [default_greeting],
+        "ON": False,
+        "CHANNEL": None,
+        "WHISPER": False,
+        "BOTS_MSG": None,
+        "BOTS_ROLE": None,
+        "LEAVE_MSG": [default_leave],
+        "LEAVE_ON": False,
+        "LEAVE_CHANNEL": None,
     }
 
     def __init__(self, bot: Red):
@@ -24,7 +31,7 @@ class Welcome:
 
         self._welcome.register_guild(**self.default_guild_settings)
 
-    @commands.group(pass_context=True, no_pm=True)
+    @commands.group(no_pm=True)
     @checks.admin_or_permissions(manage_guild=True)
     async def welcomeset(self, ctx):
         """Sets welcome module settings"""
@@ -34,24 +41,26 @@ class Welcome:
             await ctx.send_help()
             msg = "```"
             msg += "Random GREETING: {}\n".format(rand_choice(settings["GREETING"]))
-            msg += "CHANNEL: #{}\n".format(await self.get_welcome_channel(guild))
-            msg += "ON: {}\n".format(settings["ON"])
+            msg += "WELCOME_CHANNEL: #{}\n".format(await self.get_welcome_channel(guild))
+            msg += "WELCOME_ON: {}\n".format(settings["ON"])
+            msg += "Random LEAVE_MSG: {}\n".format(rand_choice(settings["LEAVE_MSG"]))
+            msg += "LEAVE_CHANNEL: #{}\n".format(await self.get_leave_channel(guild))
+            msg += "LEAVE_ON: {}\n".format(settings["ON"])
             msg += "WHISPER: {}\n".format(settings["WHISPER"])
             msg += "BOTS_MSG: {}\n".format(settings["BOTS_MSG"])
             msg += "BOTS_ROLE: {}\n".format(settings["BOTS_ROLE"])
             msg += "```"
             await ctx.send(msg)
 
-    @welcomeset.group(pass_context=True, name="msg")
+    @welcomeset.group(name="msg")
     async def welcomeset_msg(self, ctx):
         """Manage welcome messages
         """
-        if ctx.invoked_subcommand is None or \
-                isinstance(ctx.invoked_subcommand, commands.Group):
+        if ctx.invoked_subcommand is None or isinstance(ctx.invoked_subcommand, commands.Group):
             await ctx.send_help()
             return
 
-    @welcomeset_msg.command(pass_context=True, name="add", no_pm=True)
+    @welcomeset_msg.command(name="add", no_pm=True)
     async def welcomeset_msg_add(self, ctx, *, format_msg):
         """Adds a welcome message format for the guild to be chosen at random
 
@@ -71,50 +80,107 @@ class Welcome:
         await ctx.send("Welcome message added for the guild.")
         await self.send_testing_msg(ctx, msg=format_msg)
 
-    @welcomeset_msg.command(pass_context=True, name="del", no_pm=True)
+    @welcomeset_msg.command(name="addleave", no_pm=True)
+    async def welcomeset_leavemsg_add(self, ctx, *, format_msg):
+        """Adds a leave message format for the guild to be chosen at random
+
+        {0} is user
+        {1} is guild
+        Default is set to:
+            {0.name} ({0.id}) has left the server."""
+        guild = ctx.guild
+        settings = await self._welcome.guild(guild).all()
+        settings["LEAVE_MSG"].append(format_msg)
+        await self._welcome.guild(guild).set(settings)
+        await ctx.send("Leave message added for the guild.")
+        await self.send_testing_msg(ctx, leave=True, msg=format_msg)
+
+    @welcomeset_msg.command(name="del", no_pm=True)
     async def welcomeset_msg_del(self, ctx):
         """Removes a welcome message from the random message list
         """
         guild = ctx.guild
         author = ctx.author
         settings = await self._welcome.guild(guild).GREETING()
-        msg = 'Choose a welcome message to delete:\n\n'
+        msg = "Enter the number of the welcome message to delete:\n\n"
         for c, m in enumerate(settings):
             msg += "  {}. {}\n".format(c, m)
-        for page in pagify(msg, ['\n', ' '], shorten_by=20):
+        for page in pagify(msg, ["\n", " "], shorten_by=20):
             await ctx.send("```\n{}\n```".format(page))
 
         def check(m):
             return author == m.author
-        answer = await self.bot.wait_for('message', timeout=120, check=check)
+
+        answer = await self.bot.wait_for("message", timeout=120, check=check)
         try:
             num = int(answer.content)
             choice = settings.pop(num)
         except:
-            await ctx.send("That's not a number in the list :/")
-            return
+            return await ctx.send("That's not a number in the list :/")
         if not settings:
             settings = [self.default_greeting]
         await ctx.send("**This message was deleted:**\n{}".format(choice))
         await self._welcome.guild(guild).GREETING.set(settings)
 
-    @welcomeset_msg.command(pass_context=True, name="list", no_pm=True)
+    @welcomeset_msg.command(name="delleave", no_pm=True)
+    async def welcomeset_leavemsg_del(self, ctx):
+        """Removes a leave message from the random message list
+        """
+        guild = ctx.guild
+        author = ctx.author
+        settings = await self._welcome.guild(guild).LEAVE_MSG()
+        msg = "Enter the number of the leave message to delete:\n\n"
+        for c, m in enumerate(settings):
+            msg += "  {}. {}\n".format(c, m)
+        for page in pagify(msg, ["\n", " "], shorten_by=20):
+            await ctx.send("```\n{}\n```".format(page))
+
+        def check(m):
+            return author == m.author
+
+        answer = await self.bot.wait_for("message", timeout=120, check=check)
+        try:
+            num = int(answer.content)
+            choice = settings.pop(num)
+        except:
+            return await ctx.send("That's not a number in the list :/")
+        if not settings:
+            settings = [self.default_greeting]
+        await ctx.send("**This message was deleted:**\n{}".format(choice))
+        await self._welcome.guild(guild).LEAVE_MSG.set(settings)
+
+    @welcomeset_msg.command(name="list", no_pm=True)
     async def welcomeset_msg_list(self, ctx):
         """Lists the welcome messages of this guild
         """
         guild = ctx.guild
         settings = await self._welcome.guild(guild).GREETING()
-        msg = 'Welcome messages:\n\n'
+        msg = "Welcome messages:\n\n"
         for c, m in enumerate(settings):
             msg += "  {}. {}\n".format(c, m)
-        for page in pagify(msg, ['\n', ' '], shorten_by=20):
+        for page in pagify(msg, ["\n", " "], shorten_by=20):
             await ctx.send("```\n{}\n```".format(page))
 
-    @welcomeset.command(pass_context=True)
+    @welcomeset_msg.command(name="listleave", no_pm=True)
+    async def welcomeset_leavemsg_list(self, ctx):
+        """Lists the leave messages of this guild
+        """
+        guild = ctx.guild
+        settings = await self._welcome.guild(guild).LEAVE_MSG()
+        msg = "Welcome messages:\n\n"
+        for c, m in enumerate(settings):
+            msg += "  {}. {}\n".format(c, m)
+        for page in pagify(msg, ["\n", " "], shorten_by=20):
+            await ctx.send("```\n{}\n```".format(page))
+
+    @welcomeset.command()
     async def toggle(self, ctx):
         """Turns on/off welcoming new users to the guild"""
         guild = ctx.guild
         settings = await self._welcome.guild(guild).ON()
+        channel = await self._welcome.guild(guild).LEAVE_CHANNEL()
+        if not channel:
+            await self._welcome.guild(guild).LEAVE_CHANNEL.set(ctx.channel.id)
         settings = not settings
         if settings:
             await ctx.send("I will now welcome new users to the guild.")
@@ -123,37 +189,64 @@ class Welcome:
             await ctx.send("I will no longer welcome new users.")
         await self._welcome.guild(guild).ON.set(settings)
 
-    @welcomeset.command(pass_context=True)
-    async def channel(self, ctx, channel: discord.TextChannel=None):
-        """Sets the channel to send the welcome message
+    @welcomeset.command()
+    async def leavetoggle(self, ctx):
+        """Turns on/off the message for people leaving the guild"""
+        guild = ctx.guild
+        settings = await self._welcome.guild(guild).LEAVE_ON()
+        channel = await self._welcome.guild(guild).LEAVE_CHANNEL()
+        if not channel:
+            await self._welcome.guild(guild).LEAVE_CHANNEL.set(ctx.channel.id)
+        settings = not settings
+        if settings:
+            await ctx.send("I will now announce when people leave the guild.")
+            await self.send_testing_msg(ctx, leave=True)
+        else:
+            await ctx.send("I will no longer announce when people leave.")
+        await self._welcome.guild(guild).LEAVE_ON.set(settings)
 
-        If channel isn't specified, the guild's default channel will be used"""
+    @welcomeset.command()
+    async def channel(self, ctx, channel: discord.TextChannel = None):
+        """Sets the channel to send the welcome message"""
         guild = ctx.guild
         channel = await self.get_welcome_channel(guild) if channel is None else channel
         if channel is None:
             channel = ctx.channel
         settings = channel.id
-        if not guild.get_member(self.bot.user.id
-                                ).permissions_in(channel).send_messages:
-            await ctx.send("I do not have permissions to send "
-                           "messages to {0.mention}".format(channel))
-            return
-        await channel.send("I will now send welcome "
-                           "messages to {0.mention}".format(channel))
-        await self.send_testing_msg(ctx)
+        if not guild.get_member(self.bot.user.id).permissions_in(channel).send_messages:
+            return await ctx.send(
+                "I do not have permissions to send " "messages to {0.mention}".format(channel)
+            )
+        await channel.send("I will now send welcome " "messages to {0.mention}".format(channel))
         await self._welcome.guild(guild).CHANNEL.set(settings)
+        await self.send_testing_msg(ctx)
 
-    @welcomeset.group(pass_context=True, name="bot", no_pm=True)
+    @welcomeset.command()
+    async def leavechannel(self, ctx, channel: discord.TextChannel = None):
+        """Sets the channel to send the leave message"""
+        guild = ctx.guild
+        channel = await self.get_leave_channel(guild) if channel is None else channel
+        if channel is None:
+            channel = ctx.channel
+        settings = channel.id
+        if not guild.get_member(self.bot.user.id).permissions_in(channel).send_messages:
+            return await ctx.send(
+                "I do not have permissions to send " "messages to {0.mention}".format(channel)
+            )
+
+        await channel.send("I will now send leaving " "messages to {0.mention}".format(channel))
+        await self._welcome.guild(guild).LEAVE_CHANNEL.set(settings)
+        await self.send_testing_msg(ctx, leave=True)
+
+    @welcomeset.group(name="bot", no_pm=True)
     async def welcomeset_bot(self, ctx):
-        """Special welcome for bots"""
-        if ctx.invoked_subcommand is None or \
-                isinstance(ctx.invoked_subcommand, commands.Group):
-            await ctx.send_help()
-            return
+        """Bot settings for message and role given."""
+        if ctx.invoked_subcommand is None or isinstance(ctx.invoked_subcommand, commands.Group):
+            return await ctx.send_help()
 
-    @welcomeset_bot.command(pass_context=True, name="msg", no_pm=True)
+    @welcomeset_bot.command(name="msg", no_pm=True)
     async def welcomeset_bot_msg(self, ctx, *, format_msg=None):
-        """Set the welcome msg for bots.
+        """Set the welcome message for bots.
 
         Leave blank to reset to regular user welcome"""
         guild = ctx.guild
@@ -161,26 +254,31 @@ class Welcome:
         settings = format_msg
         await self._welcome.guild(guild).BOTS_MSG.set(settings)
         if format_msg is None:
-            await ctx.send("Bot message reset. Bots will now be welcomed as regular users.")
+            await ctx.send(
+                "Bot message reset. Bots will now be welcomed as regular users if welcome messages are enabled."
+            )
         else:
             await ctx.send("Bot welcome message set for the guild.")
             await self.send_testing_msg(ctx, bot=True)
 
     # TODO: Check if have permissions
-    @welcomeset_bot.command(pass_context=True, name="role", no_pm=True)
-    async def welcomeset_bot_role(self, ctx, role: discord.Role=None):
+    @welcomeset_bot.command(name="role", no_pm=True)
+    async def welcomeset_bot_role(self, ctx, role: discord.Role = None):
         """Set the role to put bots in when they join.
-
         Leave blank to not give them a role."""
         guild = ctx.guild
         settings = await self._welcome.guild(guild).BOTS_ROLE()
         settings = role.name if role else role
-        await ctx.send("Bots that join this guild will "
-                       "now be put into the {} role".format(role.name))
         await self._welcome.guild(guild).BOTS_ROLE.set(settings)
+        if not role:
+            await ctx.send("Bots that join this guild will not have a role applied.")
+        else:
+            await ctx.send(
+                "Bots that join this guild will " "now be put into the {} role.".format(role.name)
+            )
 
-    @welcomeset.command(pass_context=True)
-    async def whisper(self, ctx, choice: str=None):
+    @welcomeset.command()
+    async def whisper(self, ctx, choice: str = None):
         """Sets whether or not a DM is sent to the new user
 
         Options:
@@ -204,25 +302,30 @@ class Welcome:
         if not settings:
             await ctx.send("I will no longer send DMs to new users")
         elif settings == "BOTH":
-            await channel.send("I will now send welcome "
-                               "messages to {0.mention} as well as to "
-                               "the new user in a DM".format(channel))
+            await channel.send(
+                "I will now send welcome "
+                "messages to {0.mention} as well as to "
+                "the new user in a DM".format(channel)
+            )
         else:
-            await channel.send("I will now only send "
-                               "welcome messages to the new user "
-                               "as a DM".format(channel))
+            await channel.send(
+                "I will now only send "
+                "welcome messages to the new user "
+                "as a DM".format(channel)
+            )
         await self.send_testing_msg(ctx)
         await self._welcome.guild(guild).WHISPER.set(settings)
 
     async def on_member_join(self, member):
         guild = member.guild
         settings = await self._welcome.guild(guild).all()
-        if not settings["ON"]:
-            return
+
         if guild is None:
-            print("guild is None. Private Message or some new fangled "
-                  "Discord thing?.. Anyways there be an error, "
-                  "the user was {}".format(member.name))
+            print(
+                "guild is None. Private Message or some new fangled "
+                "Discord thing?.. Anyways there be an error, "
+                "the user was {}".format(member.name)
+            )
             return
 
         only_whisper = settings["WHISPER"] is True
@@ -230,41 +333,77 @@ class Welcome:
         bot_role = member.bot and settings["BOTS_ROLE"]
         msg = bot_welcome or rand_choice(settings["GREETING"])
 
-        # whisper the user if needed
-        if not member.bot and settings["WHISPER"]:
-            try:
-                await member.send(msg.format(member, guild))
-            except:
-                print("welcome.py: unable to whisper {}. Probably "
-                      "doesn't want to be PM'd".format(member))
-        # grab the welcome channel
-        channel = await self.get_welcome_channel(guild)
-        if channel is None:  # complain even if only whisper
-            print('welcome.py: Channel not found. It was most '
-                  'likely deleted. User joined: {}'.format(member.name))
-            return
-        # we can stop here
-        if only_whisper and not bot_welcome:
-            return
-        if not self.speak_permissions(guild):
-            print("Permissions Error. User that joined: "
-                  "{0.name}".format(member))
-            print("Bot doesn't have permissions to send messages to "
-                  "{0.name}'s #{1.name} channel".format(guild, channel))
-            return
         # try to add role if needed
         if bot_role:
             try:
                 role = discord.utils.get(guild.roles, name=bot_role)
                 await member.add_roles(role)
             except:
-                print('welcome.py: unable to add {} role to {}. '
-                      'Role was deleted, network error, or lacking '
-                      'permissions'.format(bot_role, member))
+                print(
+                    "welcome.py: unable to add {} role to {} in {} ({}). "
+                    "Role was deleted, network error, or lacking "
+                    "permissions".format(bot_role, member, guild.name, guild.id)
+                )
             else:
-                print('welcome.py: added {} role to '
-                      'bot, {}'.format(role, member))
+                print(
+                    "welcome.py: added {} role to bot, {} in {} ({})".format(
+                        role, member, guild.name, guild.id
+                    )
+                )
+        if not settings["ON"]:
+            return
+        # whisper the user if needed
+        if not member.bot and settings["WHISPER"]:
+            try:
+                await member.send(msg.format(member, guild))
+            except:
+                print(
+                    "welcome.py: unable to whisper {}. Probably "
+                    "doesn't want to be PM'd".format(member)
+                )
+        # grab the welcome channel
+        channel = await self.get_welcome_channel(guild)
+        if channel is None:  # complain even if only whisper
+            print(
+                "welcome.py: Saved channel not found. It was most "
+                "likely not set up yet or could be a deleted channel. User joined: {}, {} ({})".format(
+                    member.name, guild.name, guild.id
+                )
+            )
+            return
+        # we can stop here
+        if only_whisper and not bot_welcome:
+            return
+        if not await self.speak_permissions(guild):
+            print(
+                "welcome.py: Permissions Error. User that joined: "
+                "{0.name}#{0.discriminator}, on server {1.name} ({1.id})".format(member, guild)
+            )
+            print(
+                "welcome.py: Bot doesn't have permissions to send messages to "
+                "{0.name}'s #{1.name} channel".format(guild, channel)
+            )
+            return
         # finally, welcome them
+        await channel.send(msg.format(member, guild))
+
+    async def on_member_remove(self, member):
+        guild = member.guild
+        settings = await self._welcome.guild(guild).all()
+        if not settings["LEAVE_ON"]:
+            return
+        if guild is None:
+            return
+        msg = rand_choice(settings["LEAVE_MSG"])
+        channel = await self.get_leave_channel(guild)
+        if channel is None:
+            print(
+                "welcome.py: Saved channel not found. It was most "
+                "likely not set up yet or could be a deleted channel. User joined: {}, {} ({})".format(
+                    member.name, guild.name, guild.id
+                )
+            )
+            return
         await channel.send(msg.format(member, guild))
 
     async def get_welcome_channel(self, guild):
@@ -274,31 +413,56 @@ class Welcome:
         except:
             return None
 
-    async def speak_permissions(self, guild):
-        channel = await self.get_welcome_channel(guild)
+    async def get_leave_channel(self, guild):
+        settings = await self._welcome.guild(guild).LEAVE_CHANNEL()
+        try:
+            return guild.get_channel(settings)
+        except:
+            return None
+
+    async def speak_permissions(self, guild, welcome=True):
+        if welcome:
+            channel = await self.get_welcome_channel(guild)
+        else:
+            channel = await self.get_leave_channel(guild)
         if channel is None:
             return False
-        return guild.get_member(self.bot.user.id
-                                ).permissions_in(channel).send_messages
+        return guild.get_member(self.bot.user.id).permissions_in(channel).send_messages
 
-    async def send_testing_msg(self, ctx, bot=False, msg=None):
+    async def send_testing_msg(self, ctx, bot=False, leave=False, msg=None):
         guild = ctx.guild
         settings = await self._welcome.guild(guild).all()
-        channel = ctx.channel if await self.get_welcome_channel(guild) is None else await self.get_welcome_channel(guild)
+        channel = (
+            ctx.channel
+            if await self.get_welcome_channel(guild) is None
+            else await self.get_welcome_channel(guild)
+        )
+        lchannel = (
+            ctx.channel
+            if await self.get_leave_channel(guild) is None
+            else await self.get_leave_channel(guild)
+        )
         rand_msg = msg or rand_choice(settings["GREETING"])
         if channel is None:
-            await ctx.channel.send("I can't find the specified channel. "
-                                   "It might have been deleted.")
+            await ctx.channel.send(
+                "I can't find the specified channel. " "It might have been deleted."
+            )
             return
-        await ctx.channel.send("`Sending a testing message to "
-                               "`{0.mention}".format(channel))
-        if await self.speak_permissions(guild):
+
+        if not leave:
+            await ctx.channel.send("`Sending a testing message to `{0.mention}".format(channel))
+            await self.speak_permissions(guild, True)
             msg = settings["BOTS_MSG"] if bot else rand_msg
             if not bot and settings["WHISPER"]:
-                await ctx.author.send(msg.format(ctx.message.author, guild))
+                return await ctx.author.send(msg.format(ctx.message.author, guild))
             if bot or settings["WHISPER"] is not True:
-                await channel.send(msg.format(ctx.message.author, guild))
+                return await channel.send(msg.format(ctx.message.author, guild))
+        if leave:
+            await ctx.channel.send("`Sending a testing message to `{0.mention}".format(lchannel))
+            await self.speak_permissions(guild, False)
+            msg = rand_choice(settings["LEAVE_MSG"])
+            return await lchannel.send(msg.format(ctx.message.author, guild))
         else:
-            await ctx.channel.send("I do not have permissions "
-                                   "to send messages to "
-                                   "{0.mention}".format(channel))
+            await ctx.channel.send(
+                "I do not have permissions to send messages to " "{0.mention}".format(channel)
+            )


### PR DESCRIPTION
- Add leave messages and configuration
- Fixed None type error on [p]welcomeset bot role with no role name given
- Removed unneeded pass_context
- Added extra user and guild information to print statements (would be good to expand into a setting later to enable or disable informational print messages)
- Uncoupled bot role awarding from welcome toggle. Bot welcome messages are tied to the main welcome message toggle. Bots that join can be awarded a role on join without a welcome message being posted.
- Black formatting