### PR TITLE
[Advgoogle] Remove case requirements for the trigger phrase

### DIFF
--- a/advgoogle/advgoogle.py
+++ b/advgoogle/advgoogle.py
@@ -168,7 +168,7 @@ class AdvancedGoogle:
     async def on_message(self, message):
         ctx = await self.bot.get_context(message)
         str2find = "ok google "
-        text = message.clean_content
+        text = message.clean_content.lower()
         if not text.startswith(str2find):
             return
         text = text.replace(str2find, "", 1)


### PR DESCRIPTION
This will improve the overall utility of the advgoogle cog by making it a little more intuitive to use by removing the case requirements from the `ok google` trigger phrase.

![image](https://user-images.githubusercontent.com/26130695/43547779-e27f4ed8-95a1-11e8-933f-af98a352628a.png)
