### PR TITLE
[Longcat] load_bundled_data is loooooong gone

### DIFF
--- a/longcat/__init__.py
+++ b/longcat/__init__.py
@@ -1,8 +1,7 @@
-from redbot.core import data_manager, commands
+from redbot.core import commands
 from .longcat import Longcat
 
 
 def setup(bot: commands.Bot):
     cog = Longcat(bot)
-    data_manager.load_bundled_data(cog, __file__)
     bot.add_cog(cog)


### PR DESCRIPTION
Gets rid of an informational message on cog load about the depreciation.