### PR TITLE
Info.json "author" field is now a list of strings

### DIFF
--- a/advgoogle/info.json
+++ b/advgoogle/info.json
@@ -1,5 +1,5 @@
 {
-    "author": ["Kowlin and Aioxas"],
+    "author": ["Kowlin", "Aioxas"],
     "install_msg": "Thanks for installing this. \nYou can start your search by doing [p]google or saying \"ok google cats\" without quotations",
     "name": "Advanced Google",
     "short": "Retrieves results from Google",

--- a/advgoogle/info.json
+++ b/advgoogle/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Kowlin and Aioxas",
+    "author": ["Kowlin and Aioxas"],
     "install_msg": "Thanks for installing this. \nYou can start your search by doing [p]google or saying \"ok google cats\" without quotations",
     "name": "Advanced Google",
     "short": "Retrieves results from Google",

--- a/emote/info.json
+++ b/emote/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Aioxas",
+    "author": ["Aioxas"],
     "install_msg": "Thanks for installing my cog. \n[p]help Emote to start using the cog.",
     "name": "emote",
     "short": "Local emote summoning, has the ability to add, remove, or list emotes. Based on irdumb's sadface cog",

--- a/geico/info.json
+++ b/geico/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Aioxas",
+    "author": ["Aioxas"],
     "install_msg": "Thanks for installing my cog. \n[p]bash and [p]quotes will be your guides.\nA 15-minute call could save you 15 percent (or more) on car insurance.",
     "name": "Geico",
     "short": "Online quote retrieval",

--- a/horoscope/info.json
+++ b/horoscope/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Aioxas",
+    "author": ["Aioxas"],
     "install_msg": "Thanks for installing my cog. \n[p]help Horoscope should be enough. If not [p]help horo, [p]help tsujiura should.",
     "name": "horoscope",
     "short": "Zodiac and Chinese Horoscope and Fortune Cookie cog",

--- a/info.json
+++ b/info.json
@@ -1,5 +1,5 @@
 {
-    "AUTHOR" : "Aioxas",
+    "AUTHOR" : ["Aioxas"],
     "INSTALL_MSG" : "Thank you for adding my repo. I hope that the cogs in here become useful to you.",
     "NAME" : "Ax-Cogs",
     "SHORT" : "Search cogs",

--- a/longcat/info.json
+++ b/longcat/info.json
@@ -1,5 +1,5 @@
 {
-    "AUTHOR" : "Aioxas",
+    "AUTHOR" : ["Aioxas"],
     "INSTALL_MSG" : "Thanks for installing my cog. \n[p]help Longcat to start using the cog.",
     "NAME" : "longcat",
     "SHORT" : "All hail Longcat. Based on canapin's longcat js command.",

--- a/loot/info.json
+++ b/loot/info.json
@@ -1,5 +1,5 @@
 {
-    "AUTHOR" : "Aioxas",
+    "AUTHOR" : ["Aioxas"],
     "INSTALL_MSG" : "Thanks for installing this cog.",
     "NAME" : "Loot",
     "SHORT" : "Keeping tabs on who paid for loot",

--- a/lootbox/info.json
+++ b/lootbox/info.json
@@ -1,5 +1,5 @@
 {
-    "AUTHOR" : "Aioxas",
+    "AUTHOR" : ["Aioxas"],
     "INSTALL_MSG" : "Thanks for installing this cog.",
     "NAME" : "Lootbox",
     "SHORT" : "Simulate lootboxes",

--- a/points/info.json
+++ b/points/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Aioxas",
+    "author": ["Aioxas"],
     "install_msg": "Thanks for installing this cog.",
     "name": "Points",
     "short": "Keep a tally of points",

--- a/strawpoll/info.json
+++ b/strawpoll/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Aioxas",
+    "author": ["Aioxas"],
     "install_msg": "Thanks for installing this cog.",
     "name": "Strawpoll",
     "short": "Create a strawpoll",

--- a/the100/info.json
+++ b/the100/info.json
@@ -1,5 +1,5 @@
 {
-    "AUTHOR" : "Aioxas",
+    "AUTHOR" : ["Aioxas"],
     "INSTALL_MSG" : "Thanks for installing my cog. \n[p]help The100 to start using the cog.",
     "NAME" : "the100",
     "SHORT" : "Bringing the100.io API to Discord",

--- a/trove/info.json
+++ b/trove/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "Aioxas/Axas",
+    "author": ["Aioxas/Axas"],
     "description": "Trove Simulator, BnS",
     "name": "Creates, and simulates trove openings",
     "tags": [

--- a/welcome/info.json
+++ b/welcome/info.json
@@ -1,5 +1,5 @@
 {
-    "author": "irdumb and Aioxas/Axas",
+    "author": ["irdumb", "Aioxas/Axas"],
     "description": "When a new user joins, the bot will send a customized message to the channel of your choice",
     "name": "Welcomes new users to your server(s)",
     "tags": [


### PR DESCRIPTION
Since the beginning of V3, the "author" field of info.json files is a list of strings. When the bot attempts to iterate on a string (expecting a list), it outputs something like `K, o, w, l, i, n,  , a, n, d,  , A, i, o, x, a, s`. This PR makes all info.json author fields into lists of strings.